### PR TITLE
ENH: Add quack compilation to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,20 @@
 
 import os
 from setuptools import setup
+from subprocess import call
+from sys import platform, argv
 
 
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
+
+# only compile quack when none of these options are chosen
+if (all([e not in argv for e in ['egg_info', 'sdist', 'register']]) and
+    platform == 'darwin'):
+    try:
+        call(['make', '-C', 'src/bg_daemon/'])
+    except OSError as e:
+        print "Can't compile quack, reason {}".format(str(e))
 
 
 setup(
@@ -21,7 +31,7 @@ setup(
     packages=["bg_daemon", "bg_daemon.fetchers"],
     package_dir={"bg_daemon": "src/bg_daemon",
                  "bg_daemon.fetchers": "src/bg_daemon/fetchers"},
-    scripts=["src/bg_daemon/background_daemon.py"],
+    scripts=["src/bg_daemon/background_daemon.py", "src/bg_daemon/quack"],
     include_package_data=True,
     data_files=[('bg_daemon', ['src/bg_daemon/settings.json',
                                'src/bg_daemon/mac-update.sh'])],

--- a/src/bg_daemon/Makefile
+++ b/src/bg_daemon/Makefile
@@ -1,0 +1,14 @@
+EX=quack
+CC=cc
+FRAMEWORKS = -framework Foundation -framework AppKit
+CFLAGS += -fobjc-arc $(FRAMEWORKS)
+#  Main target
+all: $(EX)
+
+quack:
+	$(CC) $(CFLAGS) -o $(EX) main.m
+
+#  Delete unwanted files
+clean:
+	rm -f $(EX) *.o
+

--- a/src/bg_daemon/mac-update.sh
+++ b/src/bg_daemon/mac-update.sh
@@ -2,7 +2,7 @@
 FN=${1}-temp.jpg
 cp $1 $FN
 
-if quack -h &>/dev/null; then
+if [ -x "$(command -v quack)" ]; then
     # OSX will think it's the same image if they are named the same
     # so trick it into thinking it's a different one
     quack $FN

--- a/src/bg_daemon/mac-update.sh
+++ b/src/bg_daemon/mac-update.sh
@@ -1,9 +1,14 @@
 #!/usr/bin/env bash
-osascript<<EOF
-tell application "Finder"
-    set desktop picture to POSIX file "$1"
-end tell
+if quack -h &>/dev/null; then
+    quack -i $1
+else
+    osascript<<EOF
+    tell application "Finder"
+        set desktop picture to POSIX file "$1"
+    end tell
 EOF
 
-# this is an ugly hack to force updating...
-killall Dock
+    # this is an ugly hack to force updating...
+    killall Dock
+fi
+

--- a/src/bg_daemon/mac-update.sh
+++ b/src/bg_daemon/mac-update.sh
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
+FN=${1}-temp.jpg
+cp $1 $FN
+
 if quack -h &>/dev/null; then
-    quack -i $1
+    # OSX will think it's the same image if they are named the same
+    # so trick it into thinking it's a different one
+    quack $FN
+    quack $1
+    rm $FN
 else
     osascript<<EOF
     tell application "Finder"

--- a/src/bg_daemon/main.m
+++ b/src/bg_daemon/main.m
@@ -12,23 +12,24 @@ int main(int argc, const char * argv[]) {
     NSWorkspace *workspace = [NSWorkspace sharedWorkspace];
     BOOL backgroundChanged = NO;
 
-    backgroundPicture = [args stringForKey:@"i"] ? [args stringForKey:@"i"] : [args stringForKey:@"-input"];
-
     // ghetto way to check if help is on or not
     if ([[[NSProcessInfo processInfo] arguments] containsObject:@"-h"] ||
         [[[NSProcessInfo processInfo] arguments] containsObject:@"--help"]){
-      fprintf(stdout, "quack: update your desktop background\n");
-      fprintf(stdout, "-i (--input) - input filepath to list of frames "\
-                      "and durations\n");
+      fprintf(stdout, "quack: update your main screen's desktop background\n");
+      fprintf(stdout, "\nUsage:\n");
+      fprintf(stdout, "quack <filename> [-h/--help]\n");
+      fprintf(stdout, "\nOptions:\n");
       fprintf(stdout, "-h (--help)  - print help text and exit\n");
       return ret;
     }
 
-    // do not execute a thing if the file input is not passed in
-    if (backgroundPicture == nil) {
-        fprintf(stderr, "The -i (--input) argument is required, pass in a "
-                "background picture.\n");
-        exit(1);
+    if (argc > 1){
+      backgroundPicture = [[NSString alloc] initWithCString:argv[1]
+                                                   encoding:NSUTF8StringEncoding];
+    }
+    else{
+      fprintf(stderr, "No image passed, not changing the desktop background\n");
+      exit(1);
     }
 
     backgroundChanged = [workspace setDesktopImageURL:[NSURL fileURLWithPath:backgroundPicture]

--- a/src/bg_daemon/main.m
+++ b/src/bg_daemon/main.m
@@ -1,0 +1,50 @@
+#import <Foundation/Foundation.h>
+#import <AppKit/AppKit.h>
+
+int main(int argc, const char * argv[]) {
+  int ret = 0;
+
+  @autoreleasepool {
+    NSUserDefaults *args = [NSUserDefaults standardUserDefaults];
+
+    NSError *error=nil;
+    NSString *backgroundPicture = nil;
+    NSWorkspace *workspace = [NSWorkspace sharedWorkspace];
+    BOOL backgroundChanged = NO;
+
+    backgroundPicture = [args stringForKey:@"i"] ? [args stringForKey:@"i"] : [args stringForKey:@"-input"];
+
+    // ghetto way to check if help is on or not
+    if ([[[NSProcessInfo processInfo] arguments] containsObject:@"-h"] ||
+        [[[NSProcessInfo processInfo] arguments] containsObject:@"--help"]){
+      fprintf(stdout, "quack: update your desktop background\n");
+      fprintf(stdout, "-i (--input) - input filepath to list of frames "\
+                      "and durations\n");
+      fprintf(stdout, "-h (--help)  - print help text and exit\n");
+      return ret;
+    }
+
+    // do not execute a thing if the file input is not passed in
+    if (backgroundPicture == nil) {
+        fprintf(stderr, "The -i (--input) argument is required, pass in a "
+                "background picture.\n");
+        exit(1);
+    }
+
+    backgroundChanged = [workspace setDesktopImageURL:[NSURL fileURLWithPath:backgroundPicture]
+                                            forScreen:[NSScreen mainScreen]
+                                              options:nil
+                                                error:&error];
+
+    if (!backgroundChanged){
+      fprintf(stderr, "Cannot change background image.\n");
+      ret ++;
+    }
+    if (error){
+      fprintf(stderr, "%s\n", [[error localizedDescription] UTF8String]);
+      ret ++;
+    }
+  }
+  return ret;
+}
+


### PR DESCRIPTION
If a C compiler and Make are available, quack will be compiled and
installed when running setup.py, otherwise the mac-update.sh script will
fall-back to using osascript.
