### PR TITLE
FIX: We can't use newer versions of mock

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,6 @@ setup(
         "imgurpython",
         "requests",
         "python-crontab",
-        "mock",
+        "mock==1.0.1",
         ],
 )


### PR DESCRIPTION
With mock version 1.3, the test fail as the method "assert_called_once"
is nowhere to be found. We, however, don't get a runtime error but,
instead, get an assertion error out of it. Further study must be done
with this issue in the long term.
