### PR TITLE
FIX:fetchers:imgurfetcher title string encoding

### DIFF
--- a/src/bg_daemon/fetchers/imgurfetcher.py
+++ b/src/bg_daemon/fetchers/imgurfetcher.py
@@ -282,7 +282,8 @@ class imgurfetcher:
                 if selected_image is None:
                     continue
 
-            logger.debug("Selecting Image {}".format(selected_image.title))
+            title = selected_image.title.encode("utf-8", errors='ignore')
+            logger.debug("Selecting Image {}".format(title))
             attempts += 1
             if attempts > 30:
                 return None

--- a/src/info.json
+++ b/src/info.json
@@ -1,0 +1,1 @@
+{"description": null, "author": "N/A", "section": "EarthPorn", "views": 1351, "link": "http://i.imgur.com/NVoTiPC.jpg", "title": "Trinity Alps, CA "}


### PR DESCRIPTION
The title string as obtained from the imgur library doesn't encode
characters in either ascii or utf-8, but provides a Unicode object
(which I never seem to understand). This causes a crash when trying to
log a title that contains extraneous characters (as it can be seen
with the multiplication sign under https://imgur.com/6KswIQG).

We force UTF-8 encoding on the title string to avoid this issue.
